### PR TITLE
begin adding v2 api

### DIFF
--- a/Controllers/V1/ProfilerController.cs
+++ b/Controllers/V1/ProfilerController.cs
@@ -4,10 +4,11 @@ using ParadisePublicAPI.Models;
 using ParadisePublicAPI.ProfilerDatabase;
 using Swashbuckle.AspNetCore.Annotations;
 
-namespace ParadisePublicAPI.Controllers {
+namespace ParadisePublicAPI.Controllers.V1 {
     /// <summary>
     /// Profiler
     /// </summary>
+    [ApiExplorerSettings(GroupName = "v1")]
     [SwaggerTag("Query proc times from the profiler. Old data may be cleared with no notice")]
     [Route("profiler")]
     public class ProfilerController : Controller {

--- a/Controllers/V1/StatsController.cs
+++ b/Controllers/V1/StatsController.cs
@@ -10,10 +10,11 @@ using ParadisePublicAPI.Database;
 using ParadisePublicAPI.Models;
 using Swashbuckle.AspNetCore.Annotations;
 
-namespace ParadisePublicAPI.Controllers {
+namespace ParadisePublicAPI.Controllers.V1 {
     /// <summary>
     /// Controller for querying statistics from game rounds
     /// </summary>
+    [ApiExplorerSettings(GroupName = "v1")]
     [SwaggerTag("Query statistics from game rounds")]
     [Route("stats")]
     public class StatsController : Controller {

--- a/Controllers/V2/StatsController.cs
+++ b/Controllers/V2/StatsController.cs
@@ -1,0 +1,62 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using ParadisePublicAPI.Database;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace ParadisePublicAPI.Controllers.V2
+{
+    /// <summary>
+    /// Controller for querying statistics from game rounds
+    /// </summary>
+    [ApiExplorerSettings(GroupName = "v2")]
+    [SwaggerTag("Query statistics from game rounds")]
+    [Route("v2/stats")]
+    public class StatsController : Controller {
+        private readonly paradise_gamedbContext _context;
+
+        public StatsController(paradise_gamedbContext context) {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Gets the data of a specific feedback key for the specified rounds.
+        /// </summary>
+        /// <param name="key_name">The name of the desired feedback key.</param>
+        /// <param name="start_date">The start date to retrieve data for.</param>
+        /// <param name="end_date">The end date to retrieve data for.</param>
+        /// <returns>A list of key-value objects, where "data" is the feedback data and "round_id" is the round ID the data was recorded.</returns>
+        /// <response code="200">Round data successfully retrieved</response>
+        /// <response code="429">Rate limited by server</response>
+        [HttpGet("feedback")]
+        public IActionResult GetFeedbackRow([FromQuery, Required] string key_name, [FromQuery, Required] DateOnly start_date, [FromQuery, Required] DateOnly end_date) {
+            if (key_name == null) {
+                return BadRequest("No feedback key_name specified.");
+            }
+            if (start_date > end_date) {
+                return BadRequest($"start_date {start_date} is later than end_date {end_date}");
+            }
+            if (start_date.AddMonths(2) < end_date) {
+                return BadRequest("Only two months of data may be requested in one query.");
+            }
+            var start_datetime = start_date.ToDateTime(TimeOnly.MinValue);
+            var end_datetime = end_date.ToDateTime(TimeOnly.MaxValue);
+            var feedbacks = (from feedback in _context.Feedbacks
+                             join round in _context.Rounds on feedback.RoundId equals round.Id
+                             orderby round.Id
+                             where feedback.KeyName == key_name
+                                 && round.ShutdownDatetime != null
+                                 && round.InitializeDatetime >= start_datetime
+                                 && round.InitializeDatetime <= end_datetime
+                             // feedback.JSON begins with `{"data": ...` so we strip the first curly brace
+                             // in order to interpolate the rest of the JSON data into the resultant string
+                             select $"{{\"round_id\": {round.Id}, {feedback.Json.Substring(1)}");
+
+            return new ContentResult()
+            {
+                Content = "[" + string.Join(", ", feedbacks) + "]",
+                ContentType = "application/json",
+                StatusCode = 200
+            };
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -21,6 +21,12 @@ builder.Services.AddSwaggerGen(options => {
         Title = "Paradise Public API",
         Description = "Paradise Station public API for data querying. This API may change with no notice.<br>Source: <a href=\"https://github.com/ParadiseSS13/ParadisePublicAPI\">https://github.com/ParadiseSS13/ParadisePublicAPI</a><br>Requests are limited to 500 every minute, and 3600 every hour."
     });
+    options.SwaggerDoc("v2", new OpenApiInfo
+    {
+        Version = "v2",
+        Title = "Paradise Public API",
+        Description = "Paradise Station public API for data querying. This API may change with no notice.<br>Source: <a href=\"https://github.com/ParadiseSS13/ParadisePublicAPI\">https://github.com/ParadiseSS13/ParadisePublicAPI</a><br>Requests are limited to 500 every minute, and 3600 every hour."
+    });
 });
 
 // Setup Game DB
@@ -71,6 +77,7 @@ WebApplication app = builder.Build();
 app.UseSwagger();
 app.UseSwaggerUI(options => {
     options.SwaggerEndpoint("swagger/v1/swagger.json", "v1");
+    options.SwaggerEndpoint("swagger/v2/swagger.json", "v2");
     options.RoutePrefix = String.Empty;
     
 });


### PR DESCRIPTION
This PR creates a v2 API namespace for Parastats, and adds its first method.

Besides any new API endpoints not present on v1, the v2 namespace is differentiated because it returns JSON-formatted results of feedback data, rather than a stringified JSON value.

`/v2/stats/feedback`:
- accepts a feedback key `key_name`, and two dates, `start_date` and `end_date`, which must consist of a span of two months max.
- returns a list of objects which provide a round ID and the data of the feedback for that round's `key_name`.

This makes it painless to quickly perform queries on individual feedback keys and helps to lessen the need for mirroring feedback data locally:

![2025_05_26__12_15_54__parastats_v2… (2) - JupyterLab](https://github.com/user-attachments/assets/028e184e-96e1-4ca8-b58b-d5369312fc44)

The LINQ query resolves nicely into a single SQL query which runs quickly. Concatenating the strings together the way we're doing here is a tiny bit slower, but not egregiously so for queries limited to two months max.